### PR TITLE
set redirect status to 307

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-modules.exports = function redirectToHTTPS (ignoreHosts, ignoreRoutes) {
+module.exports = function redirectToHTTPS (ignoreHosts, ignoreRoutes) {
   if (!ignoreHosts) {
     ignoreHosts = [];
   }
@@ -13,7 +13,7 @@ modules.exports = function redirectToHTTPS (ignoreHosts, ignoreRoutes) {
       ignoreHosts.indexOf(req.get('host')) === -1 &&
       ignoreRoutes.indexOf(req.path) === -1
     )  {
-      return res.redirect('https://' + req.get('host') + req.url);
+      return res.redirect(307,'https://' + req.get('host') + req.url);
     }
 
     next();


### PR DESCRIPTION
Fixe module.export error
set redirect status to 307: "The difference between 307 and 302 is that 307 guarantees that the method and the body will not be changed when the redirected request is made. With 302, some old clients were incorrectly changing the method to GET: the behavior with non-GET methods and 302 is then unpredictable on the Web, whereas the 307 one is".(HTTP DOC)